### PR TITLE
add decoratorsLegacy option to @babel/preset-stage-2 in .babelrc

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,3 @@
 {
-  "presets": ["@babel/env", "@babel/stage-2", "@babel/react"]
+  "presets": ["@babel/env", ["@babel/preset-stage-2", { "decoratorsLegacy": true }], "@babel/react"]
 }


### PR DESCRIPTION
A Error has been occurred since a few days ago when `npm run build` runs.
The error message says,

> webpack:///./src/server/server.js?:1
throw new Error("Module build failed: Error: [BABEL] /Applications/mampstack-5.6.29-2/apache2/htdocs/_Myproject/react-kanban/src/server/server.js: **The new decorators proposal is not supported yet. You must pass the `\"decoratorsLegacy\":true` option to @babel/preset-stage-2** (While processing: \"/Applications/mampstack-5.6.29-2/apache2/htdocs/_Myproject/react-kanban/node_modules/@babel/preset-stage-2/lib/index.js\")\n    at /Applications/mampstack-5.6.29-2/apache2/htdocs/_Myproject/react-kanban/node_modules/@babel/preset-stage-2/lib/index.js:107:11\n    at /Applications/mampstack-5.6.29-2/apache2/htdocs/_Myproject/react-kanban/node_modules/@babel/helper-plugin-utils/lib/index.js:18:12\n    at /Applications/mampstack-5.6.29-2/apache2/htdocs/_Myproject/react-kanban/node_modules/@babel/core/lib/config/full.js:172:14\n    at cachedFunction (/Applications/mampstack-5.6.29-2/apache2/htdocs/_Myproject/react-kanban/node_modules/@babel/core/lib/config/caching.js:42:17)\n    at lo

So, I added `{ "decoratorsLegacy": true }` option to babel/preset-stage-2 in .babelrc file.
And it works well!